### PR TITLE
Implement neon glass marketing site

### DIFF
--- a/dataspark/frontend/.env.local
+++ b/dataspark/frontend/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_SITE_NAME="dataspark"

--- a/dataspark/frontend/app/globals.css
+++ b/dataspark/frontend/app/globals.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply min-h-screen bg-radial from-[#0B143B] via-[#041B56] to-[#001735] text-slate-100;
+}

--- a/dataspark/frontend/app/page.tsx
+++ b/dataspark/frontend/app/page.tsx
@@ -1,12 +1,20 @@
-import Hero from '../components/Hero'
+import Hero from "../components/Hero";
+import Challenge from "../components/Challenge";
+import ServicesGrid from "../components/ServicesGrid";
+import StatsBar from "../components/StatsBar";
+import CtaBanner from "../components/CtaBanner";
 
 export default function Home() {
   return (
-    <main className="min-h-screen flex flex-col">
+    <main className="flex flex-col">
       <Hero />
-      <footer className="mt-auto p-4 text-center text-sm text-gray-500">
+      <Challenge />
+      <ServicesGrid />
+      <StatsBar />
+      <CtaBanner />
+      <footer className="mt-auto p-4 text-center text-sm text-slate-400">
         &copy; {new Date().getFullYear()} Dataspark
       </footer>
     </main>
-  )
+  );
 }

--- a/dataspark/frontend/components/Challenge.tsx
+++ b/dataspark/frontend/components/Challenge.tsx
@@ -1,0 +1,44 @@
+import Image from "next/image";
+import GlassCard from "./GlassCard";
+import Section from "./Section";
+
+const challenges = [
+  {
+    title: "Untapped Potential",
+    copy: "99 % of mid-market firms sit on dormant data gold—unused, unseen.",
+  },
+  {
+    title: "Decision Bottlenecks",
+    copy: "Manual reporting slows decision speed. Teams lose hours stitching CSVs.",
+  },
+  {
+    title: "Competitive Disadvantage",
+    copy: "While you wrestle with basics, rivals deploy advanced analytics to win market share.",
+  },
+];
+
+export default function Challenge() {
+  return (
+    <Section>
+      <div className="grid md:grid-cols-2 gap-8 items-center">
+        <div className="space-y-6">
+          {challenges.map((ch) => (
+            <GlassCard key={ch.title} className="p-6">
+              <h3 className="font-semibold text-white mb-1">{ch.title}</h3>
+              <p className="text-slate-300 text-sm">{ch.copy}</p>
+            </GlassCard>
+          ))}
+        </div>
+        <div className="relative h-64 md:h-80">
+          <Image
+            src="https://images.unsplash.com/photo-1529156069898-49953e39b3ac?auto=format&fit=crop&w=800&q=80"
+            alt="Overworked analyst"
+            fill
+            className="object-cover rounded-2xl"
+            priority
+          />
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/dataspark/frontend/components/CtaBanner.tsx
+++ b/dataspark/frontend/components/CtaBanner.tsx
@@ -1,0 +1,48 @@
+import Section from "./Section";
+import {
+  CalendarDaysIcon,
+  ComputerDesktopIcon,
+  RocketLaunchIcon,
+} from "@heroicons/react/24/outline";
+
+const steps = [
+  {
+    icon: CalendarDaysIcon,
+    title: "Book a Discovery Call",
+    desc: "30-min, zero-cost scoping.",
+  },
+  {
+    icon: ComputerDesktopIcon,
+    title: "Get Custom Proposal",
+    desc: "Clear deliverables & timeline.",
+  },
+  {
+    icon: RocketLaunchIcon,
+    title: "Start Seeing Results",
+    desc: "Impact in weeks, not months.",
+  },
+];
+
+export default function CtaBanner() {
+  return (
+    <Section className="text-center">
+      <h2 className="text-3xl font-extrabold tracking-tight mb-10">
+        Ready to turn numbers into growth?
+      </h2>
+      <ol className="relative max-w-md mx-auto border-l border-accent/50 space-y-8">
+        {steps.map((step) => (
+          <li key={step.title} className="ml-6">
+            <span className="absolute -left-3 flex h-6 w-6 items-center justify-center rounded-full bg-accent/20">
+              <step.icon className="h-4 w-4 text-accent drop-shadow-[0_0_4px_#00E2FF]" />
+            </span>
+            <h3 className="font-semibold text-white">{step.title}</h3>
+            <p className="text-sm text-slate-300">{step.desc}</p>
+          </li>
+        ))}
+      </ol>
+      <p className="mt-10 text-sm text-slate-300">
+        team@dataspark.ai ｜ +49 30 5557 8900
+      </p>
+    </Section>
+  );
+}

--- a/dataspark/frontend/components/GlassCard.tsx
+++ b/dataspark/frontend/components/GlassCard.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+interface GlassCardProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function GlassCard({
+  children,
+  className = "",
+}: GlassCardProps) {
+  return (
+    <div
+      className={`bg-white/5 backdrop-blur-sm ring-1 ring-cyan-400/30 rounded-2xl ${className}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/dataspark/frontend/components/Hero.tsx
+++ b/dataspark/frontend/components/Hero.tsx
@@ -1,30 +1,60 @@
-'use client'
+"use client";
 
-import HeroGradient from './HeroGradient'
-import { motion } from 'framer-motion'
+import Image from "next/image";
+import { motion } from "framer-motion";
+import Section from "./Section";
 
 export default function Hero() {
   return (
-    <section className="text-center py-20">
-      {/* Visual hero section using ReactBits */}
-      <HeroGradient className="mx-auto max-w-2xl">
+    <Section className="relative flex items-center justify-center min-h-[60vh] text-center">
+      {/* Background photo */}
+      <Image
+        src="https://images.unsplash.com/photo-1556157382-97eda2d62296?auto=format&fit=crop&w=1600&q=80"
+        alt="City skyline"
+        fill
+        priority
+        className="object-cover absolute inset-0 -z-20"
+      />
+      <div className="absolute inset-0 bg-black/60 -z-10" />
+
+      {/* Animated gradient blob */}
+      <motion.div
+        className="absolute inset-0 flex items-center justify-center -z-10"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+      >
+        <motion.div
+          className="w-96 h-96 rounded-full bg-brand-500/30 blur-3xl"
+          animate={{ scale: [1, 1.3, 1] }}
+          transition={{ repeat: Infinity, duration: 8 }}
+        />
+      </motion.div>
+
+      <div className="space-y-6 relative">
         <motion.h1
-          className="text-4xl font-bold mb-4"
+          className="text-5xl font-extrabold tracking-tight drop-shadow-[0_0_4px_#00E2FF]"
           initial={{ opacity: 0, y: -10 }}
           animate={{ opacity: 1, y: 0 }}
         >
-          Data Science that Delivers ROI
+          Data Science, Delivered as Growth.
         </motion.h1>
-        <p className="mb-6 text-gray-600">
-          Spend less time guessing, more time growing.
-        </p>
-        <a
-          href="/contact"
-          className="inline-block bg-brand-500 text-white px-6 py-3 rounded-md"
+        <motion.p
+          className="text-lg text-slate-300 mx-auto max-w-xl"
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0, delay: 0.2 }}
         >
-          Book a Call
-        </a>
-      </HeroGradient>
-    </section>
-  )
+          From messy spreadsheets to live dashboards—turn raw numbers into ROI.
+        </motion.p>
+        <motion.a
+          href="/contact"
+          aria-label="Book a Discovery Call"
+          className="inline-block px-6 py-3 rounded-md bg-brand-500 text-white drop-shadow-[0_0_4px_#00E2FF]"
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0, delay: 0.4 }}
+        >
+          Book a Discovery Call
+        </motion.a>
+      </div>
+    </Section>
+  );
 }

--- a/dataspark/frontend/components/Section.tsx
+++ b/dataspark/frontend/components/Section.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+interface SectionProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function Section({ children, className = "" }: SectionProps) {
+  return (
+    <section className={`py-20 lg:py-24 ${className}`}>
+      <div className="max-w-7xl mx-auto px-4">{children}</div>
+    </section>
+  );
+}

--- a/dataspark/frontend/components/ServicesGrid.tsx
+++ b/dataspark/frontend/components/ServicesGrid.tsx
@@ -1,0 +1,59 @@
+import Image from "next/image";
+import GlassCard from "./GlassCard";
+import Section from "./Section";
+import {
+  ChartBarIcon,
+  ChartPieIcon,
+  WrenchScrewdriverIcon,
+  ClipboardDocumentCheckIcon,
+} from "@heroicons/react/24/outline";
+
+const services = [
+  {
+    icon: ChartBarIcon,
+    title: "End-to-End Analytics",
+    desc: "From data collection to actionable reports—complete solution, tailored.",
+  },
+  {
+    icon: ChartPieIcon,
+    title: "Interactive Dashboards",
+    desc: "Real-time visualisation. See your business pulse at a glance.",
+  },
+  {
+    icon: WrenchScrewdriverIcon,
+    title: "Custom AI Tools",
+    desc: "Machine-learning solutions that get smarter over time.",
+  },
+  {
+    icon: ClipboardDocumentCheckIcon,
+    title: "Data Strategy Audits",
+    desc: "Uncover hidden opportunities; map your analytics journey.",
+  },
+];
+
+export default function ServicesGrid() {
+  return (
+    <Section>
+      <div className="grid md:grid-cols-2 gap-8 items-center">
+        <div className="grid sm:grid-cols-2 gap-6 order-2 md:order-1">
+          {services.map((service) => (
+            <GlassCard key={service.title} className="p-6 space-y-2">
+              <service.icon className="h-8 w-8 text-accent drop-shadow-[0_0_4px_#00E2FF]" />
+              <h3 className="font-semibold text-white">{service.title}</h3>
+              <p className="text-slate-300 text-sm">{service.desc}</p>
+            </GlassCard>
+          ))}
+        </div>
+        <div className="relative h-64 md:h-80 order-1 md:order-2">
+          <Image
+            src="https://images.unsplash.com/photo-1665686306089-3d2845cffb32?auto=format&fit=crop&w=800&q=80"
+            alt="Engineer at big monitor"
+            fill
+            className="object-cover rounded-2xl"
+            priority
+          />
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/dataspark/frontend/components/StatCounter.tsx
+++ b/dataspark/frontend/components/StatCounter.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useInView } from "framer-motion";
+
+interface StatCounterProps {
+  to: number;
+  duration?: number;
+}
+
+export default function StatCounter({ to, duration = 1 }: StatCounterProps) {
+  const ref = useRef<HTMLSpanElement | null>(null);
+  const isInView = useInView(ref, { once: true });
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!isInView) return;
+    const start = performance.now();
+    const step = (now: number) => {
+      const progress = Math.min((now - start) / (duration * 1000), 1);
+      setCount(Math.floor(progress * to));
+      if (progress < 1) requestAnimationFrame(step);
+    };
+    requestAnimationFrame(step);
+  }, [isInView, to, duration]);
+
+  return <span ref={ref}>{count}</span>;
+}

--- a/dataspark/frontend/components/StatsBar.tsx
+++ b/dataspark/frontend/components/StatsBar.tsx
@@ -1,0 +1,27 @@
+import GlassCard from "./GlassCard";
+import Section from "./Section";
+import StatCounter from "./StatCounter";
+
+const stats = [
+  { prefix: "↑", value: 35, suffix: "% Average ROI" },
+  { prefix: "", value: 12, suffix: " Weeks to First Insights" },
+  { prefix: "+", value: 20, suffix: " Happy Clients" },
+];
+
+export default function StatsBar() {
+  return (
+    <Section>
+      <GlassCard className="p-6 flex flex-col sm:flex-row justify-around text-center">
+        {stats.map((s) => (
+          <div key={s.suffix} className="py-2">
+            <span className="text-3xl font-bold tracking-tight">
+              {s.prefix}
+              <StatCounter to={s.value} />
+              {s.suffix}
+            </span>
+          </div>
+        ))}
+      </GlassCard>
+    </Section>
+  );
+}

--- a/dataspark/frontend/next.config.mjs
+++ b/dataspark/frontend/next.config.mjs
@@ -1,0 +1,13 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "images.unsplash.com",
+      },
+    ],
+  },
+};
+
+export default nextConfig;

--- a/dataspark/frontend/package.json
+++ b/dataspark/frontend/package.json
@@ -8,6 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "autoprefixer": "^10.4.14",
     "framer-motion": "^10.12.16",
     "next": "14.0.0",

--- a/dataspark/frontend/pnpm-lock.yaml
+++ b/dataspark/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@heroicons/react':
+        specifier: ^2.2.0
+        version: 2.2.0(react@18.3.1)
       autoprefixer:
         specifier: ^10.4.14
         version: 10.4.21(postcss@8.5.4)
@@ -51,6 +54,11 @@ packages:
 
   '@emotion/memoize@0.7.4':
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
+
+  '@heroicons/react@2.2.0':
+    resolution: {integrity: sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==}
+    peerDependencies:
+      react: '>= 16 || ^19.0.0-rc'
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -680,6 +688,10 @@ snapshots:
 
   '@emotion/memoize@0.7.4':
     optional: true
+
+  '@heroicons/react@2.2.0(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
 
   '@isaacs/cliui@8.0.2':
     dependencies:

--- a/dataspark/frontend/tailwind.config.ts
+++ b/dataspark/frontend/tailwind.config.ts
@@ -1,20 +1,29 @@
-import type { Config } from 'tailwindcss'
+import type { Config } from "tailwindcss";
+import plugin from "tailwindcss/plugin";
 
-// Tailwind configuration with brand colour and dark mode
 export default {
-  darkMode: 'class',
-  content: [
-    './app/**/*.{ts,tsx}',
-    './components/**/*.{ts,tsx}'
-  ],
+  darkMode: "class",
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
   theme: {
     extend: {
       colors: {
         brand: {
-          500: '#6366f1'
-        }
-      }
-    }
+          500: "#6366f1",
+        },
+        accent: "#00E2FF",
+      },
+    },
   },
-  plugins: []
-} satisfies Config
+  plugins: [
+    plugin(function ({ addUtilities }) {
+      addUtilities({
+        ".bg-radial": {
+          "background-image": "radial-gradient(var(--tw-gradient-stops))",
+        },
+        ".bg-conic": {
+          "background-image": "conic-gradient(var(--tw-gradient-stops))",
+        },
+      });
+    }),
+  ],
+} satisfies Config;


### PR DESCRIPTION
## Summary
- apply dark neon glass theme site-wide
- create hero, challenge, services, stats and CTA components
- animate stat counters and hero blob
- configure Tailwind accent color and gradient utilities
- allow Unsplash images via `next.config.mjs`

## Testing
- `pnpm exec prettier --write .`
- `pnpm run build` *(fails: bg-radial class issue - fixed)*

------
https://chatgpt.com/codex/tasks/task_e_6840812bf9b48332be7e0c6710d815c6