### PR TITLE
Remove duplicate hero component

### DIFF
--- a/dataspark/frontend/app/page.tsx
+++ b/dataspark/frontend/app/page.tsx
@@ -1,9 +1,7 @@
-import Hero from "../components/Hero";
-
 export default function Home() {
   return (
     <main className="min-h-screen">
-      <Hero />
+      {/* Content goes here */}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- stop rendering `<Hero>` component in page since layout renders it already

## Testing
- `pnpm lint` *(fails: Command "lint" not found)*
- `pnpm build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409ad32de48332826f0c278211a2fb