### PR TITLE
Restore homepage content

### DIFF
--- a/dataspark/frontend/app/layout.tsx
+++ b/dataspark/frontend/app/layout.tsx
@@ -10,7 +10,7 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="min-h-screen bg-[#001F3F] text-white overflow-y-auto">
+      <body className="min-h-screen bg-[#000033] text-white overflow-y-auto overscroll-none">
         <Hero />
         {children}
       </body>

--- a/dataspark/frontend/app/page.tsx
+++ b/dataspark/frontend/app/page.tsx
@@ -1,7 +1,18 @@
+import Challenge from "../components/Challenge";
+import ServicesGrid from "../components/ServicesGrid";
+import StatsBar from "../components/StatsBar";
+import CtaBanner from "../components/CtaBanner";
+
 export default function Home() {
   return (
-    <main className="min-h-screen">
-      {/* Content goes here */}
+    <main className="flex flex-col">
+      <Challenge />
+      <ServicesGrid />
+      <StatsBar />
+      <CtaBanner />
+      <footer className="mt-auto p-4 text-center text-sm text-slate-400">
+        &copy; {new Date().getFullYear()} Dataspark
+      </footer>
     </main>
   );
 }

--- a/dataspark/frontend/components/Hero.tsx
+++ b/dataspark/frontend/components/Hero.tsx
@@ -4,7 +4,7 @@ import LetterGlitch from "./LetterGlitch";
 
 export default function Hero() {
   return (
-    <section className="relative flex items-center justify-center min-h-[60vh] text-center bg-[#001F3F]">
+    <section className="relative flex items-center justify-center min-h-[60vh] text-center bg-[#000033]">
       <LetterGlitch
         glitchSpeed={50}
         centerVignette={true}


### PR DESCRIPTION
## Summary
- add back Challenge, ServicesGrid, StatsBar and CtaBanner components
- darken page background and disable overscroll
- match Hero section color to new background

## Testing
- `pnpm install`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68409bd018cc8332bc47c5940f796e79