### PR TITLE
Fix header gradient transition

### DIFF
--- a/dataspark/frontend/components/Hero.tsx
+++ b/dataspark/frontend/components/Hero.tsx
@@ -4,7 +4,7 @@ import LetterGlitch from "./LetterGlitch";
 
 export default function Hero() {
   return (
-    <section className="relative flex items-center justify-center min-h-[60vh] text-center bg-[#000033]">
+    <section className="relative flex items-center justify-center min-h-[60vh] text-center bg-transparent">
       <LetterGlitch
         glitchSpeed={50}
         centerVignette={true}

--- a/dataspark/frontend/components/LetterGlitch.tsx
+++ b/dataspark/frontend/components/LetterGlitch.tsx
@@ -230,7 +230,9 @@ const LetterGlitch = ({
     position: 'relative',
     width: '100%',
     height: '100%',
-    background: 'linear-gradient(to bottom, #000000, #102040, #61b3cd)', // Smooth transition
+    // Extend gradient to match the page background colour
+    background:
+      'linear-gradient(to bottom, #000000 0%, #102040 40%, #61b3cd 80%, #2b4539 100%)',
     overflow: 'hidden',
   };
 


### PR DESCRIPTION
## Summary
- extend header gradient to fade into page background
- remove redundant background color on hero section

## Testing
- `pnpm --dir frontend build`

------
https://chatgpt.com/codex/tasks/task_e_6840a430fe88833294e68e2cef25ef71